### PR TITLE
ENG-55284 initial commit for Improve site-creation health check behavior

### DIFF
--- a/io/insert/service.go
+++ b/io/insert/service.go
@@ -83,7 +83,7 @@ func (s *Service) NextSequence(ctx context.Context, any interface{}, recordCount
 }
 
 // Exec runs insertService SQL
-func (s *Service) Exec(ctx context.Context, any interface{}, options ...option.Option) (int64, int64, error) {
+func (s *Service) Exec(ctx context.Context, any interface{}, options ...option.Option) (rowsAffected int64, lastInsertedID int64, err error) {
 	if options == nil {
 		options = make(option.Options, 0)
 	}
@@ -137,13 +137,16 @@ func (s *Service) Exec(ctx context.Context, any interface{}, options ...option.O
 		return 0, 0, err
 	}
 
-	if err = sess.prepare(ctx, record, batchSize); err != nil {
+	// Ensure stmt/transaction are released even if sess.insert panics.
+	defer func() {
 		err = sess.end(err)
+	}()
+
+	if err = sess.prepare(ctx, record, batchSize); err != nil {
 		return 0, 0, err
 	}
 
-	rowsAffected, lastInsertedID, err := sess.insert(ctx, batchRecordBuffer, valueAt, recordCount, identities)
-	err = sess.end(err)
+	rowsAffected, lastInsertedID, err = sess.insert(ctx, batchRecordBuffer, valueAt, recordCount, identities)
 	return rowsAffected, lastInsertedID, err
 }
 
@@ -153,37 +156,31 @@ func (s *Service) NewSession(ctx context.Context, record interface{}, db *sql.DB
 	defer s.mux.Unlock()
 	rType := reflect.TypeOf(record)
 	if sess := s.cachedSession; sess != nil && sess.rType == rType && sess.batchSize == batchSize {
-		// Reset per-call state on cached numeric sequencers before returning
-		// to avoid carrying over detected preset state between sessions.
-		for _, updater := range s.cachedSession.recordUpdaters {
-			if asNumeric, ok := updater.(*numericSequencer); ok {
-				// reset preset/sequence flags under locks
-				asNumeric.muxPreset.Lock()
-				asNumeric.muxSequenceValue.Lock()
-				asNumeric.detectedPreset = false
-				asNumeric.presetRecord = nil
-				asNumeric.presetRecordCount = 0
-				asNumeric.sequence = nil
-				asNumeric.shallPresetIdentities = true
-				asNumeric.sequenceValue = nil
-				asNumeric.muxSequenceValue.Unlock()
-				asNumeric.muxPreset.Unlock()
-			}
-		}
-
 		if db == nil {
 			db = sess.db
 		}
-		return &session{
-			recordUpdaters: s.cachedSession.recordUpdaters,
-			rType:          rType,
-			Config:         sess.Config,
-			binder:         sess.binder,
-			columns:        sess.columns,
-			db:             db,
-			batchSize:      sess.batchSize,
-			info:           sess.info,
-		}, nil
+		newSess := &session{
+			rType:     rType,
+			Config:    sess.Config,
+			binder:    sess.binder,
+			columns:   sess.columns,
+			db:        db,
+			batchSize: sess.batchSize,
+			info:      sess.info,
+		}
+		// Build fresh recordUpdaters bound to newSess so per-call state
+		// (sequence, sequenceValue, detectedPreset, ...) is not shared
+		// across concurrent Exec calls.
+		newSess.recordUpdaters = make([]recordUpdater, 0, len(sess.recordUpdaters))
+		for _, ru := range sess.recordUpdaters {
+			if asNumeric, ok := ru.(*numericSequencer); ok {
+				newSess.recordUpdaters = append(newSess.recordUpdaters,
+					newNumericSequencer(newSess, asNumeric.getColumn(), asNumeric.columnPosition()))
+				continue
+			}
+			newSess.recordUpdaters = append(newSess.recordUpdaters, ru)
+		}
+		return newSess, nil
 	}
 
 	aDialect, err := config.Dialect(ctx, s.db)

--- a/io/insert/service_concurrent_test.go
+++ b/io/insert/service_concurrent_test.go
@@ -1,0 +1,93 @@
+package insert
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewSession_FreshUpdatersPerCall verifies that reusing a cached
+// session does not share numericSequencer instances across sessions.
+// Sharing led to a nil-pointer panic in updateRecord when one goroutine
+// reset n.sequenceValue while another was mid-flight.
+func TestNewSession_FreshUpdatersPerCall(t *testing.T) {
+	type entity struct {
+		ID   int `sqlx:"name=foo_id,primaryKey=true,generator=autoincrement"`
+		Name string
+	}
+
+	svc := &Service{tableName: "t"}
+
+	cached := &session{rType: reflect.TypeOf(&entity{}), batchSize: 1}
+	cached.recordUpdaters = []recordUpdater{
+		newNumericSequencer(cached, nil, 0),
+	}
+	svc.cachedSession = cached
+
+	s1, err := svc.NewSession(context.Background(), &entity{}, nil, 1)
+	require.NoError(t, err)
+	s2, err := svc.NewSession(context.Background(), &entity{}, nil, 1)
+	require.NoError(t, err)
+
+	require.Len(t, s1.recordUpdaters, 1)
+	require.Len(t, s2.recordUpdaters, 1)
+	require.NotSame(t, s1.recordUpdaters[0], s2.recordUpdaters[0],
+		"each session must own its numericSequencer")
+	require.NotSame(t, s1.recordUpdaters[0], cached.recordUpdaters[0],
+		"cached sequencer must not be reused by a returned session")
+
+	n1 := s1.recordUpdaters[0].(*numericSequencer)
+	n2 := s2.recordUpdaters[0].(*numericSequencer)
+	require.Same(t, s1, n1.session)
+	require.Same(t, s2, n2.session)
+	require.False(t, n1.detectedPreset)
+	require.False(t, n2.detectedPreset)
+	require.Nil(t, n1.sequenceValue)
+	require.Nil(t, n2.sequenceValue)
+}
+
+// TestNewSession_ConcurrentNoSharedState runs NewSession from many
+// goroutines and asserts every returned session has its own sequencer
+// pointer, which is what eliminates the upstream race that caused the
+// production nil-pointer panic.
+func TestNewSession_ConcurrentNoSharedState(t *testing.T) {
+	type entity struct {
+		ID   int `sqlx:"name=foo_id,primaryKey=true,generator=autoincrement"`
+		Name string
+	}
+
+	svc := &Service{tableName: "t"}
+	cached := &session{rType: reflect.TypeOf(&entity{}), batchSize: 1}
+	cached.recordUpdaters = []recordUpdater{
+		newNumericSequencer(cached, nil, 0),
+	}
+	svc.cachedSession = cached
+
+	const goroutines = 64
+	seen := make([]*numericSequencer, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			s, err := svc.NewSession(context.Background(), &entity{}, nil, 1)
+			if err != nil {
+				t.Errorf("NewSession: %v", err)
+				return
+			}
+			seen[idx] = s.recordUpdaters[0].(*numericSequencer)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < goroutines; i++ {
+		require.NotNil(t, seen[i])
+		for j := i + 1; j < goroutines; j++ {
+			require.NotSame(t, seen[i], seen[j],
+				"goroutines %d and %d share a sequencer", i, j)
+		}
+	}
+}


### PR DESCRIPTION
Site creation service is seeing a go panic error, and the service does not function as expected (not responding to requests). However the health check is still functional and reporting 200 OK, but site miss inserts will not succeed.

Issues:
sqlx reused one mutable numericSequencer across concurrent inserts, which caused the nil-pointer panic race.
sqlx also didn’t guarantee sess.end() on panic, which could leak DB transaction/statement resources.
Mediator changes are hardening and safety nets; real root fix is the sqlx patch.
	
FIX:
stopped sharing numericSequencer state across concurrent sessions and always runs sess.end(...) via defer, so no nil-pointer race and no leaked DB resources on panic.